### PR TITLE
🚧 Implement random_resample_by_blocks()

### DIFF
--- a/bootstrapping_tools/__init__.py
+++ b/bootstrapping_tools/__init__.py
@@ -1,5 +1,5 @@
 """GECI Tools for bootstrapping"""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 from .bootstrapping import *  # noqa
 from .resample_by_blocks import *  # noqa

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -241,7 +241,7 @@ def bootstrap_from_time_series(
 
 def resample_data(dataframe, seed, blocks_length=2):
     random.seed(seed)
-    return random_resample_data_by_blocks(dataframe, blocks_length)
+    return random_resample_data_by_blocks(dataframe, blocks_length).sort_index()
 
 
 def calculate_p_values(distribution):

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -201,6 +201,7 @@ def bootstrap_from_time_series(
     return_distribution=False,
     remove_outliers=True,
     outlier_method="tukey",
+    blocks_length=2,
     **kwargs,
 ):
     """Calculate 95% bootstrap intervals for lambda coefficient in population growth model from timeseries data.
@@ -221,7 +222,7 @@ def bootstrap_from_time_series(
     rand = 0
     print("Calculating bootstrap growth rates distribution:")
     while cont < N:
-        resampled_data = resample_data(dataframe, rand)
+        resampled_data = resample_data(dataframe, rand, blocks_length)
         try:
             fitting_result = lambda_calculator(
                 resampled_data["Temporada"], resampled_data[column_name]
@@ -239,7 +240,7 @@ def bootstrap_from_time_series(
     return np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
 
 
-def resample_data(dataframe, seed, blocks_length=2):
+def resample_data(dataframe, seed, blocks_length):
     random.seed(seed)
     return random_resample_data_by_blocks(dataframe, blocks_length)
 

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pandas as pd
+import random
 
+from .resample_by_blocks import random_resample_data_by_blocks
 from scipy.optimize import curve_fit
 from tqdm import tqdm
 
@@ -219,7 +221,7 @@ def bootstrap_from_time_series(
     rand = 0
     print("Calculating bootstrap growth rates distribution:")
     while cont < N:
-        resampled_data = _resample_data(dataframe, rand)
+        resampled_data = resample_data(dataframe, rand)
         try:
             fitting_result = lambda_calculator(
                 resampled_data["Temporada"], resampled_data[column_name]
@@ -236,6 +238,9 @@ def bootstrap_from_time_series(
         return lambdas_bootstraps, np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
     return np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
 
+def resample_data(dataframe, rand, blocks_length = 1):
+    random.seed(rand)
+    return(random_resample_data_by_blocks(dataframe, blocks_length).sort_index())
 
 def _resample_data(dataframe, seed):
     resampled_data = dataframe.sample(

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -241,7 +241,7 @@ def bootstrap_from_time_series(
 
 def resample_data(dataframe, seed, blocks_length=2):
     random.seed(seed)
-    return random_resample_data_by_blocks(dataframe, blocks_length).sort_index()
+    return random_resample_data_by_blocks(dataframe, blocks_length)
 
 
 def calculate_p_values(distribution):

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -221,7 +221,7 @@ def bootstrap_from_time_series(
     rand = 0
     print("Calculating bootstrap growth rates distribution:")
     while cont < N:
-        resampled_data = _resample_data(dataframe, rand)
+        resampled_data = resample_data(dataframe, rand)
         try:
             fitting_result = lambda_calculator(
                 resampled_data["Temporada"], resampled_data[column_name]
@@ -241,15 +241,6 @@ def bootstrap_from_time_series(
 def resample_data(dataframe, seed, blocks_length = 2):
     random.seed(seed)
     return random_resample_data_by_blocks(dataframe, blocks_length) 
-
-def _resample_data(dataframe, seed):
-    resampled_data = dataframe.sample(
-        n=len(dataframe), replace=True, random_state=seed
-    ).sort_index()
-    return resampled_data
-
-def aux_resample_data(dataframe, seed):
-    return _resample_data(dataframe, seed)
 
 def calculate_p_values(distribution):
     """Calculate p-values based on proportion of samples greater than 1, and below 1.0

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -238,9 +238,11 @@ def bootstrap_from_time_series(
         return lambdas_bootstraps, np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
     return np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
 
-def resample_data(dataframe, seed, blocks_length = 2):
+
+def resample_data(dataframe, seed, blocks_length=2):
     random.seed(seed)
-    return random_resample_data_by_blocks(dataframe, blocks_length) 
+    return random_resample_data_by_blocks(dataframe, blocks_length)
+
 
 def calculate_p_values(distribution):
     """Calculate p-values based on proportion of samples greater than 1, and below 1.0

--- a/bootstrapping_tools/bootstrapping.py
+++ b/bootstrapping_tools/bootstrapping.py
@@ -221,7 +221,7 @@ def bootstrap_from_time_series(
     rand = 0
     print("Calculating bootstrap growth rates distribution:")
     while cont < N:
-        resampled_data = resample_data(dataframe, rand)
+        resampled_data = _resample_data(dataframe, rand)
         try:
             fitting_result = lambda_calculator(
                 resampled_data["Temporada"], resampled_data[column_name]
@@ -238,9 +238,9 @@ def bootstrap_from_time_series(
         return lambdas_bootstraps, np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
     return np.percentile(lambdas_bootstraps, [2.5, 50, 97.5])
 
-def resample_data(dataframe, rand, blocks_length = 1):
-    random.seed(rand)
-    return(random_resample_data_by_blocks(dataframe, blocks_length).sort_index())
+def resample_data(dataframe, seed, blocks_length = 2):
+    random.seed(seed)
+    return random_resample_data_by_blocks(dataframe, blocks_length) 
 
 def _resample_data(dataframe, seed):
     resampled_data = dataframe.sample(
@@ -248,6 +248,8 @@ def _resample_data(dataframe, seed):
     ).sort_index()
     return resampled_data
 
+def aux_resample_data(dataframe, seed):
+    return _resample_data(dataframe, seed)
 
 def calculate_p_values(distribution):
     """Calculate p-values based on proportion of samples greater than 1, and below 1.0

--- a/bootstrapping_tools/resample_by_blocks.py
+++ b/bootstrapping_tools/resample_by_blocks.py
@@ -9,7 +9,7 @@ def random_resample_data_by_blocks(original_sample, blocks_length):
     block_labels = random.choices(block_labels, k=length_block_labels)
     rows = _get_rows(block_labels, n_rows_original, blocks_length)
     resample = original_sample.loc[rows, :]
-    return resample.reset_index(drop=True)
+    return resample
 
 
 def resample_data_by_blocks(original_sample, blocks_length):

--- a/bootstrapping_tools/resample_by_blocks.py
+++ b/bootstrapping_tools/resample_by_blocks.py
@@ -8,15 +8,7 @@ def random_resample_data_by_blocks(original_sample, blocks_length):
     length_block_labels = len(block_labels)
     block_labels = random.choices(block_labels, k=length_block_labels)
     rows = _get_rows(block_labels, n_rows_original, blocks_length)
-    resample = original_sample.loc[rows, :]
-    return resample
-
-
-def resample_data_by_blocks(original_sample, blocks_length):
-    n_rows_original = len(original_sample)
-    block_labels = _get_labels(n_rows_original, blocks_length)
-    rows = _get_rows(block_labels, n_rows_original, blocks_length)
-    resample = original_sample.loc[rows, :]
+    resample = original_sample.iloc[rows, :].reset_index(drop=True)
     return resample
 
 

--- a/bootstrapping_tools/resample_by_blocks.py
+++ b/bootstrapping_tools/resample_by_blocks.py
@@ -9,7 +9,7 @@ def random_resample_data_by_blocks(original_sample, blocks_length):
     block_labels = random.choices(block_labels, k=length_block_labels)
     rows = _get_rows(block_labels, n_rows_original, blocks_length)
     resample = original_sample.loc[rows, :]
-    return resample
+    return resample.reset_index(drop=True)
 
 
 def resample_data_by_blocks(original_sample, blocks_length):

--- a/tests/test_bootstrapping.py
+++ b/tests/test_bootstrapping.py
@@ -67,6 +67,7 @@ data_nest = pd.DataFrame(
     }
 )
 
+
 def test_lambdas_bootstrap_from_dataframe():
     obtained_lambdas_bootstrap = lambdas_bootstrap_from_dataframe(
         data_nest, "Nest", N=20, remove_outliers=False

--- a/tests/test_bootstrapping.py
+++ b/tests/test_bootstrapping.py
@@ -14,6 +14,8 @@ from bootstrapping_tools import (
     remove_outlier,
     remove_distribution_outliers,
     seasons_from_date,
+    resample_data,
+    aux_resample_data
 )
 
 
@@ -67,6 +69,11 @@ data_nest = pd.DataFrame(
     }
 )
 
+def test_resample_data():
+    obtained = resample_data(data_nest, 2)
+    obtained_2 = aux_resample_data(data_nest, 2)
+    assert False
+
 
 def test_lambdas_bootstrap_from_dataframe():
     obtained_lambdas_bootstrap = lambdas_bootstrap_from_dataframe(
@@ -93,13 +100,13 @@ def test_get_bootstrap_interval():
 
 def test_bootstrap_from_time_series():
     obtained_bootstrap_from_time_series = bootstrap_from_time_series(
-        data_nest, "Nest", N=20, remove_outliers=False
+        data_nest, "Nest", N=100, remove_outliers=False
     )
     expected_bootstrap_from_time_series = np.array([1.78180307, 1.82117423, 1.94509028])
     are_close = np.isclose(
         expected_bootstrap_from_time_series, obtained_bootstrap_from_time_series, rtol=1e-5
     ).all()
-    assert are_close
+    assert are_close, "Intervalo del 95% difiere"
 
 
 def test_calculate_p_values():

--- a/tests/test_bootstrapping.py
+++ b/tests/test_bootstrapping.py
@@ -14,8 +14,6 @@ from bootstrapping_tools import (
     remove_outlier,
     remove_distribution_outliers,
     seasons_from_date,
-    resample_data,
-    aux_resample_data
 )
 
 
@@ -69,12 +67,6 @@ data_nest = pd.DataFrame(
     }
 )
 
-def test_resample_data():
-    obtained = resample_data(data_nest, 2)
-    obtained_2 = aux_resample_data(data_nest, 2)
-    assert False
-
-
 def test_lambdas_bootstrap_from_dataframe():
     obtained_lambdas_bootstrap = lambdas_bootstrap_from_dataframe(
         data_nest, "Nest", N=20, remove_outliers=False
@@ -102,7 +94,7 @@ def test_bootstrap_from_time_series():
     obtained_bootstrap_from_time_series = bootstrap_from_time_series(
         data_nest, "Nest", N=100, remove_outliers=False
     )
-    expected_bootstrap_from_time_series = np.array([1.78180307, 1.82117423, 1.94509028])
+    expected_bootstrap_from_time_series = np.array([1.77056253, 1.79716642, 1.82920025])
     are_close = np.isclose(
         expected_bootstrap_from_time_series, obtained_bootstrap_from_time_series, rtol=1e-5
     ).all()

--- a/tests/test_resample_by_blocks.py
+++ b/tests/test_resample_by_blocks.py
@@ -55,7 +55,7 @@ class Tester_By_Size_Blocks:
 
     def assert_random_resampled_by_blocks(self):
         obtained = random_resample_data_by_blocks(self.data, self.blocks_length)
-        assert_frame_equal(self.expected.reset_index(drop=True), obtained.reset_index(drop=True))
+        assert_frame_equal(self.expected.reset_index(drop=True), obtained)
 
     def set_expected(self, column_a, column_b):
         self.expected = self._data_from_columns(column_a, column_b)

--- a/tests/test_resample_by_blocks.py
+++ b/tests/test_resample_by_blocks.py
@@ -1,25 +1,8 @@
 import pandas as pd
 import numpy as np
 from pandas.testing import assert_frame_equal
-from bootstrapping_tools import resample_data_by_blocks, random_resample_data_by_blocks
+from bootstrapping_tools import random_resample_data_by_blocks
 import random
-
-
-def test_resample_data_by_blocks():
-    blocks_length = 1
-    block_size_1 = Tester_By_Size_Blocks(blocks_length)
-    block_size_1.set_expected([10, 20, 30, 40, 50], [600, 700, 800, 900, 1000])
-    block_size_1.assert_resampled_by_blocks()
-    blocks_length = 3
-    block_size_3 = Tester_By_Size_Blocks(blocks_length)
-    block_size_3.set_expected([10, 20, 30, 20, 30, 40], [600, 700, 800, 700, 800, 900])
-    block_size_3.assert_resampled_by_blocks()
-    blocks_length = 4
-    block_size_4 = Tester_By_Size_Blocks(blocks_length)
-    block_size_4.set_expected(
-        [10, 20, 30, 40, 20, 30, 40, 50], [600, 700, 800, 900, 700, 800, 900, 1000]
-    )
-    block_size_4.assert_resampled_by_blocks()
 
 
 def test_random_resample_data_by_blocks():
@@ -49,16 +32,12 @@ class Tester_By_Size_Blocks:
         self.data = None
         self._set_data()
 
-    def assert_resampled_by_blocks(self):
-        obtained = resample_data_by_blocks(self.data, self.blocks_length)
-        assert_frame_equal(self.expected.reset_index(drop=True), obtained.reset_index(drop=True))
-
     def assert_random_resampled_by_blocks(self):
         obtained = random_resample_data_by_blocks(self.data, self.blocks_length)
-        assert_frame_equal(self.expected.reset_index(drop=True), obtained.reset_index(drop=True))
+        assert_frame_equal(self.expected, obtained)
 
     def set_expected(self, column_a, column_b):
-        self.expected = self._data_from_columns(column_a, column_b)
+        self.expected = self._data_from_columns(column_a, column_b).reset_index(drop=True)
 
     def _set_data(self):
         self.data = self._data_from_columns(np.arange(10, 60, 10), np.arange(600, 1100, 100))

--- a/tests/test_resample_by_blocks.py
+++ b/tests/test_resample_by_blocks.py
@@ -55,7 +55,7 @@ class Tester_By_Size_Blocks:
 
     def assert_random_resampled_by_blocks(self):
         obtained = random_resample_data_by_blocks(self.data, self.blocks_length)
-        assert_frame_equal(self.expected.reset_index(drop=True), obtained)
+        assert_frame_equal(self.expected.reset_index(drop=True), obtained.reset_index(drop=True))
 
     def set_expected(self, column_a, column_b):
         self.expected = self._data_from_columns(column_a, column_b)


### PR DESCRIPTION
🔖⚡️✨Implement `random_resample_by_blocks()`. 

- ✨Agregamos opción `blocks_length` en `bootstrap_from_time_series()`
- El remuestro tiene los índices ordenados
- 🔖Aumentamos la versión a `v0.5.0`
- 🔥Eliminamos `resample_by_block()`
## Pendientes
- Sobreviven 42 👾 